### PR TITLE
Property names can contain underscores (for now)

### DIFF
--- a/toggle-validation-schema.json
+++ b/toggle-validation-schema.json
@@ -1,10 +1,10 @@
 {
    "type":"object",
    "propertyNames":{
-      "pattern":"^[A-Za-z][A-Za-z0-9]*$"
+      "pattern":"^[A-Za-z][A-Za-z_]*$"
    },
    "patternProperties":{
-      "[a-zA-Z]*":{
+      "[a-zA-Z_]*":{
          "$ref":"#/definitions/toggle"
       }
    },


### PR DESCRIPTION
In the legacy application, sometimes underscores are used as properties. So we enable it, untill everything is migrated to services/modules